### PR TITLE
Refactors to use region enum instead of strings.

### DIFF
--- a/codegen/s3.rs
+++ b/codegen/s3.rs
@@ -11340,11 +11340,11 @@ impl MaxPartsWriter {
 }
 pub struct S3Client<'a> {
 	creds: &'a AWSCredentials,
-	region: &'a str
+	region: &'a Region
 }
 
 impl<'a> S3Client<'a> {
-	pub fn new(creds: &'a AWSCredentials, region: &'a str) -> S3Client<'a> {
+	pub fn new(creds: &'a AWSCredentials, region: &'a Region) -> S3Client<'a> {
 		S3Client { creds: creds, region: region }
 	}
 	/// Returns metadata about all of the versions of objects in a bucket.
@@ -11980,7 +11980,8 @@ impl<'a> S3Client<'a> {
 	/// Creates a new bucket.
 	/// All requests go to the us-east-1/us-standard endpoint, but can create buckets anywhere.
 	pub fn create_bucket(&self, input: &CreateBucketRequest) -> Result<CreateBucketOutput, AWSError> {
-		let mut request = SignedRequest::new("PUT", "s3", "us-east-1", "");
+		let region = Region::UsEast1;
+		let mut request = SignedRequest::new("PUT", "s3", &region, "");
 		let hostname = format!("{}.s3.amazonaws.com", input.bucket);
 		request.set_hostname(Some(hostname));
 
@@ -12071,7 +12072,7 @@ impl<'a> S3Client<'a> {
 	/// Deletes the bucket. All objects (including all object versions and Delete
 	/// Markers) in the bucket must be deleted before the bucket itself can be
 	/// deleted.
-	pub fn delete_bucket(&self, input: &DeleteBucketRequest, region: &str) -> Result<(), AWSError> {
+	pub fn delete_bucket(&self, input: &DeleteBucketRequest, region: &Region) -> Result<(), AWSError> {
 		let mut request = SignedRequest::new("DELETE", "s3", region, "");
 
 		let hostname = (&input.bucket).to_string() + ".s3.amazonaws.com";

--- a/codegen/sqs.rs
+++ b/codegen/sqs.rs
@@ -182,7 +182,7 @@ pub struct SetQueueAttributesRequest {
 	///   * `MaximumMessageSize` \- The limit of how many bytes a message can contain before Amazon SQS rejects it. An integer from 1024 bytes (1 KiB) up to 262144 bytes (256 KiB). The default for this attribute is 262144 (256 KiB).
 	///   * `MessageRetentionPeriod` \- The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days). The default for this attribute is 345600 (4 days).
 	///   * `Policy` \- The queue's policy. A valid AWS policy. For more information about policy structure, see [Overview of AWS IAM Policies](http://docs.aws.amazon.com/IAM/latest/UserGuide/PoliciesOverview.html) in the _Amazon IAM User Guide_.
-	///   * `ReceiveMessageWaitTimeSeconds` \- The time for which a ReceiveMessage call will wait for a message to arrive. An integer from 0 to 20 (seconds). The default for this attribute is 0. 
+	///   * `ReceiveMessageWaitTimeSeconds` \- The time for which a ReceiveMessage call will wait for a message to arrive. An integer from 0 to 20 (seconds). The default for this attribute is 0.
 	///   * `VisibilityTimeout` \- The visibility timeout for the queue. An integer from 0 to 43200 (12 hours). The default for this attribute is 30. For more information about visibility timeout, see Visibility Timeout in the _Amazon SQS Developer Guide_.
 	///   * `RedrivePolicy` \- The parameters for dead letter queue functionality of the source queue. For more information about RedrivePolicy and dead letter queues, see Using Amazon SQS Dead Letter Queues in the _Amazon SQS Developer Guide_.
 	pub attributes: AttributeMap,
@@ -315,7 +315,7 @@ pub struct CreateQueueRequest {
 	///   * `MaximumMessageSize` \- The limit of how many bytes a message can contain before Amazon SQS rejects it. An integer from 1024 bytes (1 KiB) up to 262144 bytes (256 KiB). The default for this attribute is 262144 (256 KiB).
 	///   * `MessageRetentionPeriod` \- The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days). The default for this attribute is 345600 (4 days).
 	///   * `Policy` \- The queue's policy. A valid AWS policy. For more information about policy structure, see [Overview of AWS IAM Policies](http://docs.aws.amazon.com/IAM/latest/UserGuide/PoliciesOverview.html) in the _Amazon IAM User Guide_.
-	///   * `ReceiveMessageWaitTimeSeconds` \- The time for which a ReceiveMessage call will wait for a message to arrive. An integer from 0 to 20 (seconds). The default for this attribute is 0. 
+	///   * `ReceiveMessageWaitTimeSeconds` \- The time for which a ReceiveMessage call will wait for a message to arrive. An integer from 0 to 20 (seconds). The default for this attribute is 0.
 	///   * `VisibilityTimeout` \- The visibility timeout for the queue. An integer from 0 to 43200 (12 hours). The default for this attribute is 30. For more information about visibility timeout, see [Visibility Timeout](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AboutVT.html) in the _Amazon SQS Developer Guide_.
 	pub attributes: Option<AttributeMap>,
 	/// The name for the queue to be created.
@@ -2619,11 +2619,11 @@ impl SendMessageBatchRequestEntryWriter {
 }
 pub struct SQSClient<'a> {
 	creds: &'a AWSCredentials,
-	region: &'a str
+	region: &'a Region
 }
 
-impl<'a> SQSClient<'a> { 
-	pub fn new(creds: &'a AWSCredentials, region: &'a str) -> SQSClient<'a> {
+impl<'a> SQSClient<'a> {
+	pub fn new(creds: &'a AWSCredentials, region: &'a Region) -> SQSClient<'a> {
 		SQSClient { creds: creds, region: region }
 	}
 	/// Creates a new queue, or returns the URL of an existing one. When you request
@@ -2660,7 +2660,7 @@ impl<'a> SQSClient<'a> {
 		stack.next(); // xml start tag
 		stack.next();
 		match status {
-			200 => { 
+			200 => {
 				Ok(try!(CreateQueueResultParser::parse_xml("CreateQueueResult", &mut stack)))
 			}
 			_ => { Err(AWSError::new("error")) }
@@ -2703,7 +2703,7 @@ impl<'a> SQSClient<'a> {
 		stack.next(); // xml start tag
 		stack.next();
 		match status {
-			200 => { 
+			200 => {
 				Ok(try!(GetQueueAttributesResultParser::parse_xml("GetQueueAttributesResult", &mut stack)))
 			}
 			_ => { Err(AWSError::new("error")) }
@@ -2729,7 +2729,7 @@ impl<'a> SQSClient<'a> {
 		stack.next(); // xml start tag
 		stack.next();
 		match status {
-			200 => { 
+			200 => {
 				Ok(())
 			}
 			_ => { Err(AWSError::new("error")) }
@@ -2756,7 +2756,7 @@ impl<'a> SQSClient<'a> {
 		stack.next(); // xml start tag
 		stack.next();
 		match status {
-			200 => { 
+			200 => {
 				Ok(try!(GetQueueUrlResultParser::parse_xml("GetQueueUrlResult", &mut stack)))
 			}
 			_ => { Err(AWSError::new("error")) }
@@ -2786,7 +2786,7 @@ impl<'a> SQSClient<'a> {
 		stack.next(); // xml start tag
 		stack.next();
 		match status {
-			200 => { 
+			200 => {
 				Ok(try!(DeleteMessageBatchResultParser::parse_xml("DeleteMessageBatchResult", &mut stack)))
 			}
 			_ => { Err(AWSError::new("error")) }
@@ -2827,7 +2827,7 @@ impl<'a> SQSClient<'a> {
 		stack.next(); // xml start tag
 		stack.next();
 		match status {
-			200 => { 
+			200 => {
 				Ok(try!(SendMessageBatchResultParser::parse_xml("SendMessageBatchResult", &mut stack)))
 			}
 			_ => { Err(AWSError::new("error")) }
@@ -2851,7 +2851,7 @@ impl<'a> SQSClient<'a> {
 		stack.next(); // xml start tag
 		stack.next();
 		match status {
-			200 => { 
+			200 => {
 				Ok(try!(ListDeadLetterSourceQueuesResultParser::parse_xml("ListDeadLetterSourceQueuesResult", &mut stack)))
 			}
 			_ => { Err(AWSError::new("error")) }
@@ -2899,7 +2899,7 @@ impl<'a> SQSClient<'a> {
 		stack.next(); // xml start tag
 		stack.next();
 		match status {
-			200 => { 
+			200 => {
 				Ok(())
 			}
 			_ => { Err(AWSError::new("error")) }
@@ -2936,7 +2936,7 @@ impl<'a> SQSClient<'a> {
 		stack.next(); // xml start tag
 		stack.next();
 		match status {
-			200 => { 
+			200 => {
 				Ok(())
 			}
 			_ => { Err(AWSError::new("error")) }
@@ -2968,7 +2968,7 @@ impl<'a> SQSClient<'a> {
 		stack.next(); // xml start tag
 		stack.next();
 		match status {
-			200 => { 
+			200 => {
 				Ok(try!(ChangeMessageVisibilityBatchResultParser::parse_xml("ChangeMessageVisibilityBatchResult", &mut stack)))
 			}
 			_ => { Err(AWSError::new("error")) }
@@ -2998,7 +2998,7 @@ impl<'a> SQSClient<'a> {
 		stack.next(); // xml start tag
 		stack.next();
 		match status {
-			200 => { 
+			200 => {
 				Ok(try!(SendMessageResultParser::parse_xml("SendMessageResult", &mut stack)))
 			}
 			_ => { Err(AWSError::new("error")) }
@@ -3032,7 +3032,7 @@ impl<'a> SQSClient<'a> {
 		stack.next(); // xml start tag
 		stack.next();
 		match status {
-			200 => { 
+			200 => {
 				Ok(())
 			}
 			_ => { Err(AWSError::new("error")) }
@@ -3059,7 +3059,7 @@ impl<'a> SQSClient<'a> {
 		stack.next(); // xml start tag
 		stack.next();
 		match status {
-			200 => { 
+			200 => {
 				Ok(())
 			}
 			_ => { Err(AWSError::new("error")) }
@@ -3078,12 +3078,12 @@ impl<'a> SQSClient<'a> {
 	/// small, you might not receive any messages in a particular `ReceiveMessage`
 	/// response; in which case you should repeat the request.
 	/// For each message returned, the response includes the following:
-	///   * Message body 
-	///   * MD5 digest of the message body. For information about MD5, go to <http://www.faqs.org/rfcs/rfc1321.html>. 
-	///   * Message ID you received when you sent the message to the queue. 
-	///   * Receipt handle. 
-	///   * Message attributes. 
-	///   * MD5 digest of the message attributes. 
+	///   * Message body
+	///   * MD5 digest of the message body. For information about MD5, go to <http://www.faqs.org/rfcs/rfc1321.html>.
+	///   * Message ID you received when you sent the message to the queue.
+	///   * Receipt handle.
+	///   * Message attributes.
+	///   * MD5 digest of the message attributes.
 	/// The receipt handle is the identifier you must provide when deleting the
 	/// message. For more information, see [Queue and Message Identifiers](http://docs
 	/// .aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/ImportantIdenti
@@ -3110,7 +3110,7 @@ impl<'a> SQSClient<'a> {
 		stack.next(); // xml start tag
 		stack.next();
 		match status {
-			200 => { 
+			200 => {
 				Ok(try!(ReceiveMessageResultParser::parse_xml("ReceiveMessageResult", &mut stack)))
 			}
 			_ => { Err(AWSError::new("error")) }
@@ -3147,7 +3147,7 @@ impl<'a> SQSClient<'a> {
 		stack.next(); // xml start tag
 		stack.next();
 		match status {
-			200 => { 
+			200 => {
 				Ok(())
 			}
 			_ => { Err(AWSError::new("error")) }
@@ -3170,7 +3170,7 @@ impl<'a> SQSClient<'a> {
 		stack.next(); // xml start tag
 		stack.next();
 		match status {
-			200 => { 
+			200 => {
 				Ok(try!(ListQueuesResultParser::parse_xml("ListQueuesResult", &mut stack)))
 			}
 			_ => { Err(AWSError::new("error")) }
@@ -3191,7 +3191,7 @@ impl<'a> SQSClient<'a> {
 		stack.next(); // xml start tag
 		stack.next();
 		match status {
-			200 => { 
+			200 => {
 				Ok(())
 			}
 			_ => { Err(AWSError::new("error")) }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -8,6 +8,7 @@ use rusoto::credentials::*;
 use rusoto::error::*;
 use rusoto::sqs::*;
 use rusoto::s3::*;
+use rusoto::regions::*;
 use time::*;
 use std::fs::File;
 use std::io::Write;
@@ -21,7 +22,6 @@ fn main() {
 		Ok(_) => { println!("Everything worked."); },
 		Err(err) => { println!("Got error: {:#?}", err); }
 	}
-
 
 	let bucket_name = format!("rusoto{}", get_time().sec);
 
@@ -82,7 +82,8 @@ fn main() {
 }
 
 fn s3_list_buckets_tests(creds: &AWSCredentials) -> Result<(), AWSError> {
-	let s3 = S3Helper::new(&creds, "us-east-1");
+	let region = Region::UsEast1;
+	let s3 = S3Helper::new(&creds, &region);
 
 	let response = try!(s3.list_buckets());
 	// println!("response is {:?}", response);
@@ -94,7 +95,8 @@ fn s3_list_buckets_tests(creds: &AWSCredentials) -> Result<(), AWSError> {
 }
 
 fn s3_get_object_test(creds: &AWSCredentials, bucket: &str) -> Result<GetObjectOutput, AWSError> {
-	let s3 = S3Helper::new(&creds, "us-east-1");
+	let region = Region::UsEast1;
+	let s3 = S3Helper::new(&creds, &region);
 
 	let response = try!(s3.get_object(bucket, "sample-credentials"));
 	// println!("get object response is {:?}", response);
@@ -102,7 +104,8 @@ fn s3_get_object_test(creds: &AWSCredentials, bucket: &str) -> Result<GetObjectO
 }
 
 fn s3_delete_object_test(creds: &AWSCredentials, bucket: &str) -> Result<DeleteObjectOutput, AWSError> {
-	let s3 = S3Helper::new(&creds, "us-east-1");
+	let region = Region::UsEast1;
+	let s3 = S3Helper::new(&creds, &region);
 
 	let response = try!(s3.delete_object(bucket, "sample-credentials"));
 	// println!("delete object response is {:?}", response);
@@ -110,7 +113,8 @@ fn s3_delete_object_test(creds: &AWSCredentials, bucket: &str) -> Result<DeleteO
 }
 
 fn s3_put_object_test(creds: &AWSCredentials, bucket: &str) -> Result<PutObjectOutput, AWSError> {
-	let s3 = S3Helper::new(&creds, "us-east-1");
+	let region = Region::UsEast1;
+	let s3 = S3Helper::new(&creds, &region);
 
 	let mut f = File::open("src/sample-credentials").unwrap();
 	let mut contents = Vec::new();
@@ -124,7 +128,8 @@ fn s3_put_object_test(creds: &AWSCredentials, bucket: &str) -> Result<PutObjectO
 }
 
 fn s3_put_object_with_reduced_redundancy_test(creds: &AWSCredentials, bucket: &str) -> Result<PutObjectOutput, AWSError> {
-	let s3 = S3Helper::new(&creds, "us-east-1");
+	let region = Region::UsEast1;
+	let s3 = S3Helper::new(&creds, &region);
 
 	let mut f = File::open("src/sample-credentials").unwrap();
 	let mut contents = Vec::new();
@@ -138,22 +143,25 @@ fn s3_put_object_with_reduced_redundancy_test(creds: &AWSCredentials, bucket: &s
 }
 
 fn s3_create_bucket_test(creds: &AWSCredentials, bucket: &str) -> Result<(), AWSError> {
-	let s3 = S3Helper::new(&creds, "us-east-1");
+	let region = Region::UsEast1;
+	let s3 = S3Helper::new(&creds, &region);
 
-	try!(s3.create_bucket_in_region(bucket, "us-east-1"));
+	try!(s3.create_bucket_in_region(bucket, &region));
 
 	Ok(())
 }
 
 fn s3_delete_bucket_test(creds: &AWSCredentials, bucket: &str) -> Result<(), AWSError> {
-	let s3 = S3Helper::new(&creds, "us-east-1");
+	let region = Region::UsEast1;
+	let s3 = S3Helper::new(&creds, &region);
 
-	try!(s3.delete_bucket(bucket, "us-east-1"));
+	try!(s3.delete_bucket(bucket, &region));
 	Ok(())
 }
 
 fn sqs_roundtrip_tests(creds: &AWSCredentials) -> Result<(), AWSError> {
-	let sqs = SQSHelper::new(&creds, "us-east-1");
+	let region = Region::UsEast1;
+	let sqs = SQSHelper::new(&creds, &region);
 
 	// list existing queues
 	let response = try!(sqs.list_queues());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,4 +16,4 @@ pub mod error;
 pub mod sqs;
 pub mod s3;
 pub mod xmlutil;
-pub mod regionchecker;
+pub mod regions;

--- a/src/regions.rs
+++ b/src/regions.rs
@@ -25,46 +25,47 @@ pub fn region_in_aws_format(region: &Region) -> String {
     }
 }
 
-// Valid Values:
-// [ us-west-1 | us-west-2 | eu-west-1 | eu-central-1 | ap-southeast-1 | ap-northeast-1 | ap-southeast-2 | sa-east-1 ]
-pub fn region_is_valid(region: &str) -> bool {
-    match region {
-        "us-west-1" => return true,
-        "us-west-2" => return true,
-        "us-east-1" => return true,
-        "eu-west-1" => return true,
-        "eu-central-1" => return true,
-        "ap-southeast-1" => return true,
-        "ap-northeast-1" => return true,
-        "ap-southeast-2" => return true,
-        "sa-east-1" => return true,
-        _ => return false
-    }
-}
-
 #[cfg(test)]
 mod tests {
 	use super::*;
 
 	#[test]
-	fn valid_regions_are_valid() {
-        let valid_regions = vec!["us-west-1", "us-west-2", "eu-west-1", "eu-central-1", "ap-southeast-1", "ap-northeast-1", "ap-southeast-2", "sa-east-1"];
-        for region in valid_regions.iter() {
-            match region_is_valid(region) {
-                true => continue,
-                false => panic!("valid region returned as not valid"),
-            }
+	fn regions_correctly_map_to_aws_strings() {
+        let mut region = Region::UsEast1;
+        if region_in_aws_format(&region) != "us-east-1" {
+            panic!("Couldn't map us-east-1 enum right.");
         }
-    }
-
-    #[test]
-	fn invalid_regions_are_invalid() {
-        let valid_regions = vec!["us-west-100", "the-moon", "Jupiter"];
-        for region in valid_regions.iter() {
-            match region_is_valid(region) {
-                true => panic!("invalid region returned as valid, broken!"),
-                false => continue,
-            }
+        region = Region::UsWest1;
+        if region_in_aws_format(&region) != "us-west-1" {
+            panic!("Couldn't map us-west-1 enum right.");
+        }
+        region = Region::UsWest2;
+        if region_in_aws_format(&region) != "us-west-2" {
+            panic!("Couldn't map us-west-2 enum right.");
+        }
+        region = Region::EuWest1;
+        if region_in_aws_format(&region) != "eu-west-1" {
+            panic!("Couldn't map eu-west-1 enum right.");
+        }
+        region = Region::EuCentral1;
+        if region_in_aws_format(&region) != "eu-central-1" {
+            panic!("Couldn't map eu-central-1 enum right.");
+        }
+        region = Region::ApSoutheast1;
+        if region_in_aws_format(&region) != "ap-southeast-1" {
+            panic!("Couldn't map ap-southeast-1 enum right.");
+        }
+        region = Region::ApNortheast1;
+        if region_in_aws_format(&region) != "ap-northeast-1" {
+            panic!("Couldn't map ap-northeast-1 enum right.");
+        }
+        region = Region::ApSoutheast2;
+        if region_in_aws_format(&region) != "ap-southeast-2" {
+            panic!("Couldn't map ap-southeast-2 enum right.");
+        }
+        region = Region::SaEast1;
+        if region_in_aws_format(&region) != "sa-east-1" {
+            panic!("Couldn't map sa-east-1 enum right.");
         }
     }
 }

--- a/src/regions.rs
+++ b/src/regions.rs
@@ -15,13 +15,13 @@ pub fn region_in_aws_format(region: &Region) -> String {
     match region {
         &Region::UsEast1 => "us-east-1".to_string(),
         &Region::UsWest1 => "us-west-1".to_string(),
-        &Region::UsWest2 => return "us-west-2".to_string(),
-        &Region::EuWest1 => return "eu-west-1".to_string(),
-        &Region::EuCentral1 => return "eu-central-1".to_string(),
-        &Region::ApSoutheast1 => return "ap-southeast-1".to_string(),
-        &Region::ApNortheast1 => return "ap-northeast-1".to_string(),
-        &Region::ApSoutheast2 => return "ap-southeast-2".to_string(),
-        &Region::SaEast1 => return "sa-east-1".to_string(),
+        &Region::UsWest2 => "us-west-2".to_string(),
+        &Region::EuWest1 => "eu-west-1".to_string(),
+        &Region::EuCentral1 => "eu-central-1".to_string(),
+        &Region::ApSoutheast1 => "ap-southeast-1".to_string(),
+        &Region::ApNortheast1 => "ap-northeast-1".to_string(),
+        &Region::ApSoutheast2 => "ap-southeast-2".to_string(),
+        &Region::SaEast1 => "sa-east-1".to_string(),
     }
 }
 

--- a/src/regions.rs
+++ b/src/regions.rs
@@ -1,3 +1,30 @@
+#[derive(Debug)]
+pub enum Region {
+    UsEast1,
+    UsWest1,
+    UsWest2,
+    EuWest1,
+    EuCentral1,
+    ApSoutheast1,
+    ApNortheast1,
+    ApSoutheast2,
+    SaEast1,
+}
+
+pub fn region_in_aws_format(region: &Region) -> String {
+    match region {
+        &Region::UsEast1 => "us-east-1".to_string(),
+        &Region::UsWest1 => "us-west-1".to_string(),
+        &Region::UsWest2 => return "us-west-2".to_string(),
+        &Region::EuWest1 => return "eu-west-1".to_string(),
+        &Region::EuCentral1 => return "eu-central-1".to_string(),
+        &Region::ApSoutheast1 => return "ap-southeast-1".to_string(),
+        &Region::ApNortheast1 => return "ap-northeast-1".to_string(),
+        &Region::ApSoutheast2 => return "ap-southeast-2".to_string(),
+        &Region::SaEast1 => return "sa-east-1".to_string(),
+    }
+}
+
 // Valid Values:
 // [ us-west-1 | us-west-2 | eu-west-1 | eu-central-1 | ap-southeast-1 | ap-northeast-1 | ap-southeast-2 | sa-east-1 ]
 pub fn region_is_valid(region: &str) -> bool {

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -6,7 +6,7 @@ use signature::*;
 use params::*;
 use error::*;
 use xmlutil::*;
-use regionchecker::*;
+use regions::*;
 use std::str::FromStr;
 use hyper::client::Response;
 use std::io::Read;
@@ -19,7 +19,7 @@ pub struct S3Helper<'a> {
 }
 
 impl<'a> S3Helper<'a> {
-	pub fn new(credentials:&'a AWSCredentials, region:&'a str) -> S3Helper<'a> {
+	pub fn new(credentials:&'a AWSCredentials, region:&'a Region) -> S3Helper<'a> {
 		S3Helper { client: S3Client::new(credentials, region) }
 	}
 
@@ -29,19 +29,22 @@ impl<'a> S3Helper<'a> {
 
 	/// Creates bucket in default us-east-1/us-standard region.
 	pub fn create_bucket(&self, bucket_name: &str) -> Result<CreateBucketOutput, AWSError> {
-		self.create_bucket_in_region(bucket_name, "us-east-1")
+		self.create_bucket_in_region(bucket_name, &Region::UsEast1)
 	}
 
 	/// Creates bucket in specified region.
-	// TODO: enum for region?
-	pub fn create_bucket_in_region(&self, bucket_name: &str, region: &str) -> Result<CreateBucketOutput, AWSError> {
+	pub fn create_bucket_in_region(&self, bucket_name: &str, region: &Region) -> Result<CreateBucketOutput, AWSError> {
 		let mut request = CreateBucketRequest::default();
 
-		// not specified means us-standard, no need to specify anything for calling AWS:
-		// also handle us-east-1 being specified: ignore it!
-		if region.len() > 0 && region_is_valid(region) && region != "us-east-1" {
-			let create_config = CreateBucketConfiguration {location_constraint: region.to_string()};
-			request.create_bucket_configuration = Some(create_config);
+		match *region {
+			Region::UsEast1 => {
+				// us-east-1 is us-standard, don't send a location constraint:
+				request.create_bucket_configuration = None;
+			}
+			_ => {
+				let create_config = CreateBucketConfiguration {location_constraint: region_in_aws_format(region)};
+				request.create_bucket_configuration = Some(create_config);
+			}
 		}
 		request.bucket = bucket_name.to_string();
 		// println!("Creating bucket");
@@ -50,7 +53,7 @@ impl<'a> S3Helper<'a> {
 		result
 	}
 
-	pub fn delete_bucket(&self, bucket_name: &str, region: &str) -> Result<(), AWSError> {
+	pub fn delete_bucket(&self, bucket_name: &str, region: &Region) -> Result<(), AWSError> {
 		let mut request = DeleteBucketRequest::default();
 		request.bucket = bucket_name.to_string();
 		// println!("Deleting bucket");
@@ -98,14 +101,17 @@ impl<'a> S3Helper<'a> {
 }
 
 // This is a bit hacky to get functionality until we figure out an XML writing util.
-pub fn create_bucket_config_xml(region: &str) -> Vec<u8> {
-	if region == "us-east-1" {
-		return Vec::new();
-	} else {
-		let xml = format!("<CreateBucketConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
-	<LocationConstraint>{}</LocationConstraint>
-	</CreateBucketConfiguration >", region);
-		return xml.into_bytes();
+pub fn create_bucket_config_xml(region: &Region) -> Vec<u8> {
+	match *region {
+		Region::UsEast1 => {
+			return Vec::new();
+		}
+		_ => {
+			let xml = format!("<CreateBucketConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">
+		<LocationConstraint>{}</LocationConstraint>
+		</CreateBucketConfiguration >", region_in_aws_format(region));
+			return xml.into_bytes();
+		}
 	}
 }
 

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -123,6 +123,7 @@ mod tests {
 	use super::ListBucketsOutputParser;
 	use super::*;
 	use xmlutil::*;
+	use regions::*;
 
 	#[test]
 	fn list_buckets_happy_path() {
@@ -142,7 +143,8 @@ mod tests {
 
 	#[test]
 	fn create_bucket_constrained_to_region() {
-		match create_bucket_config_xml("us-west-2").len() {
+		let region = Region::UsWest2;
+		match create_bucket_config_xml(&region).len() {
 			0 => panic!("us-west-2 should have bucket constraint."),
 			_ => return,
 		}
@@ -150,7 +152,8 @@ mod tests {
 
 	#[test]
 	fn create_bucket_us_east_1_no_constraints() {
-		match create_bucket_config_xml("us-east-1").len() {
+		let region = Region::UsEast1;
+		match create_bucket_config_xml(&region).len() {
 			0 => return,
 			_ => panic!("us-east-1 should not have bucket constraint."),
 		}

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -7,6 +7,7 @@ use params::*;
 use error::*;
 use xmlutil::*;
 use std::str::FromStr;
+use regions::*;
 
 // include the code generated from the SQS botocore templates
 include!(concat!(env!("CARGO_MANIFEST_DIR"), "/codegen/sqs.rs"));
@@ -16,7 +17,7 @@ pub struct SQSHelper<'a> {
 }
 
 impl<'a> SQSHelper<'a> {
-	pub fn new(credentials:&'a AWSCredentials, region:&'a str) -> SQSHelper<'a> {
+	pub fn new(credentials:&'a AWSCredentials, region:&'a Region) -> SQSHelper<'a> {
 		SQSHelper { client: SQSClient::new(credentials, region) }
 	}
 


### PR DESCRIPTION
Fixes #42.

Still need to double check use of lifetimes and add a test for the enum to AWS string function.